### PR TITLE
ARM: dts: yupik: fix mdss_dsi_phy0 compatible

### DIFF
--- a/msm-extra/display-devicetree/display/yupik-sde-common.dtsi
+++ b/msm-extra/display-devicetree/display/yupik-sde-common.dtsi
@@ -280,13 +280,13 @@
 	};
 
 	mdss_dsi_phy0: qcom,mdss_dsi_phy0@ae94900 {
-		compatible = "qcom,dsi-phy-v4.1";
+		compatible = "qcom,dsi-phy-v4.2";
 		label = "dsi-phy-0";
 		cell-index = <0>;
 		#clock-cells = <1>;
 		reg = <0xae94400 0x800>,
 		      <0xae94900 0x27c>,
-		      <0xaf01004  0x8>,
+		      <0xaf01004 0x8>,
 		      <0xae94200 0x100>;
 		reg-names = "dsi_phy", "pll_base", "gdsc_base", "dyn_refresh_base";
 		pll-label = "dsi_pll_5nm";


### PR DESCRIPTION
* According to drm code qcom,dsi-phy-v{version} should be used as per the below table
 ________________
| node | version |
| 7 nm |   4.0   |
| 7 nm |   4.1   |
| 5 nm |   4.2   |
 ----------------

* Yupik has 5nm node for disp so correct the compatible.